### PR TITLE
Add decimal data type

### DIFF
--- a/gluejobutils/data/data_type_conversion.json
+++ b/gluejobutils/data/data_type_conversion.json
@@ -27,7 +27,6 @@
     "glue": "double",
     "spark": "DoubleType"
   },
-  },
   "decimal": {
     "glue": "decimal",
     "spark": "DecimalType"

--- a/gluejobutils/data/data_type_conversion.json
+++ b/gluejobutils/data/data_type_conversion.json
@@ -27,6 +27,11 @@
     "glue": "double",
     "spark": "DoubleType"
   },
+  },
+  "decimal": {
+    "glue": "decimal",
+    "spark": "DecimalType"
+  },
   "long": {
     "glue": "bigint",
     "spark": "LongType"


### PR DESCRIPTION
This PR is linked to the [PR against ETL Manager](https://github.com/moj-analytical-services/etl_manager/pull/132) to add decimal as an allowed data type.